### PR TITLE
Fix bug in function long unsigned int *gslport_lvector(int s, int e) in ...

### DIFF
--- a/tracy/inc/gslport.h
+++ b/tracy/inc/gslport.h
@@ -83,6 +83,8 @@ double ***gslport_tensor(int t1, int t2, int r1, int r2, int s1, int s2) {
 long unsigned int *gslport_lvector(int s, int e) {
 	
 	long unsigned int *data = (long unsigned int*)malloc((e+1)*sizeof(long unsigned int));
+	
+	return data;
 
 }
 


### PR DESCRIPTION
Fix bug in function long unsigned int *gslport_lvector(int s, int e) in  gslporth. The function now returns the pointer
